### PR TITLE
Update to new interface of ocamlcfg

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -4,7 +4,9 @@ parse-docstrings = true
 wrap-comments = true
 
 break-cases = toplevel
-break-separators=after-and-docked
+break-separators=after
+space-around-lists=false
+dock-collection-brackets=false
 field-space=loose
 break-fun-decl=smart
 type-decl=sparse

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: false
 
 env:
-  - OCAML_VERSION=4.08
+  - OCAML_VERSION=4.09
 
 before_install:
   - sh <(curl -sL https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-ocaml.sh)
@@ -10,18 +10,12 @@ before_install:
 install:
   - opam switch create dev --empty
   - eval $(opam env)
-  - opam pin add -y ocaml-variants https://github.com/gretay-js/ocaml.git\#wip8
-  - opam pin add -y ocaml-migrate-parsetree https://github.com/gretay-js/ocaml-migrate-parsetree.git\#immediate64_ast408
-  - opam pin add -y ocamlcfg https://github.com/gretay-js/ocamlcfg.git\#8715c47284439557f91ca5ac5c6419189c2f11c7
+  - opam pin add -y ocaml-variants https://github.com/gretay-js/ocaml.git\#fdo409
+  - opam pin add -y ocamlcfg https://github.com/gretay-js/ocamlcfg.git\#master
 
   - ocamlc -v
 
   - opam install -y ppx_jane core async
-
-  - opam pin add -n ppx_compare https://github.com/janestreet/ppx_compare.git\#58696fd0a9aac7be49fef0ab1ff6798dad3c8a72
-  - opam pin add -n ppx_hash https://github.com/janestreet/ppx_hash.git\#b69549c05cad09a900e3708c7216761b19dae075
-  - opam install -y ppx_compare ppx_hash
-
 
 script:
   - dune build bin/main.exe

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ let rec f2 n =
 First, you need to tell the ocaml compiler to save the linear representation of your sources:
 
 ```bash
-$ ocamlopt -save-ir-after linearize -stop-after linearize test/fixtures/repetitive.ml
+$ ocamlopt -save-ir-after scheduling -stop-after scheduling test/fixtures/repetitive.ml
 ```
 
 Next, run this program on the linear file 
@@ -495,18 +495,18 @@ which takes you from one block to the other.
 With all that's been said so far, two blocks are considered equivalent *if* their instructions are equivalent
 and *if* their registers are equivalent.
 
-## Pins required
+## Install with opam: pins required
 
 The tool is currently in an experimental state, and requires specific versions of libraries to function:
 
 ```
-opam pin add ppx_compare https://github.com/janestreet/ppx_compare.git\#58696fd0a9aac7be49fef0ab1ff6798dad3c8a72
-opam pin add ppx_hash https://github.com/janestreet/ppx_hash.git\#b69549c05cad09a900e3708c7216761b19dae075
+opam switch create 409 --empty
+opam pin add ocaml-variants https://github.com/gretay-js/ocaml.git#fdo409
 opam pin add ocamlcfg https://github.com/gretay-js/ocamlcfg.git
-opam pin add ocaml-migrate-parsetree https://github.com/gretay-js/ocaml-migrate-parsetree.git\#immediate64_ast408
-opam pin add ocaml-variants https://github.com/gretay-js/ocaml.git\#wip8
+opam pin add ocaml-instr-freq https://github.com/ericpts/ocaml-instr-freq.git
 ```
 
+Requires `ppx_hash` and `ppx_compare` from `v0.13.0`.
 
 ## Tests
 

--- a/bin/dune
+++ b/bin/dune
@@ -1,7 +1,10 @@
 (executable
  (name main)
+ (public_name ocaml-instr-freq)
+ (package ocaml-instr-freq)
  (libraries
   core
+  compiler-libs.optcomp
   ocamlcfg
   instr_freq
   patterns

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -162,8 +162,9 @@ let main_command =
     ~readme:(fun () ->
       "Group contents of basic blocks based on equivalence classes, and \
        print the most common classes.")
-    [%map_open.Command.Let_syntax
-      let anon_files = anon (sequence ("input" %: Filename.arg_type))
+    Command.Let_syntax.(
+      let%map_open anon_files =
+        anon (sequence ("input" %: Filename.arg_type))
       and n_real_blocks_to_print =
         flag "-print-n-real-blocks"
           (optional_with_default 1 int)
@@ -211,21 +212,21 @@ let main_command =
         flag "-use-whole-block-matcher"
           (optional Filename.arg_type)
           ~doc:
-            "patterns_name Print only symbolic blocks which match the \
-             given whole-block matcher. The given argument should be the \
-             name of a pattern, with a matching file \
+            "patterns_name Print only symbolic blocks which match the given \
+             whole-block matcher. The given argument should be the name of \
+             a pattern, with a matching file \
              patterns/pattern_${patterns_name}"
       and context_length =
         flag "-context-length"
           (optional_with_default 0 int)
           ~doc:
             "context How much context to include when building the index. \
-             From the CFG graph,we will take chains of length [context] \
-             and treat them as single blocks.This options permits us to \
-             look at more instructions and gain better insight, however \
-             the worst-case running time is exponential in this \
-             parameter.If you change this option, then you *must* rebuild \
-             the index. Defaults to 0."
+             From the CFG graph,we will take chains of length [context] and \
+             treat them as single blocks.This options permits us to look at \
+             more instructions and gain better insight, however the \
+             worst-case running time is exponential in this parameter.If \
+             you change this option, then you *must* rebuild the index. \
+             Defaults to 0."
       in
       let matcher_of_index =
         match (subsequence_matcher, whole_block_matcher) with
@@ -258,7 +259,7 @@ let main_command =
       fun () ->
         main files ~index_file ~n_real_blocks_to_print
           ~n_most_frequent_equivalences ~block_print_mode ~min_block_size
-          ~matcher_of_index ~context_length]
+          ~matcher_of_index ~context_length)
 ;;
 
 let () = Command.run main_command

--- a/bin/patterns_gen/gen.ml
+++ b/bin/patterns_gen/gen.ml
@@ -29,13 +29,14 @@ let main_command =
   Command.basic ~summary:"Generate patterns file."
     ~readme:(fun () ->
       "To be used for automatic generation of patterns meta-file.")
-    [%map_open.Command.Let_syntax
-      let files =
+    Command.Let_syntax.(
+    let%map_open
+      files =
         anon (sequence ("ml-files-with-patterns" %: Filename.arg_type))
       and output =
         flag "-o" (required Filename.arg_type) ~doc:"Output file"
       in
-      fun () -> main ~files ~output]
+      fun () -> main ~files ~output)
 ;;
 
 let () = Command.run main_command

--- a/lib/dune
+++ b/lib/dune
@@ -2,6 +2,7 @@
  (name instr_freq)
  (libraries
   core
+  compiler-libs.optcomp
   ocamlcfg
  )
  (preprocess (pps ppx_jane))

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -1,7 +1,6 @@
 open! Core
-open Ocamlcfg
 open Equivalence
-
+module Cfg = Ocamlcfg.Cfg
 (* An index is a collection of equivalence classes *)
 module T : sig
   type t

--- a/lib/loop_free_block.ml
+++ b/lib/loop_free_block.ml
@@ -1,22 +1,24 @@
-open Ocamlcfg
 open Core
+module Cfg = Ocamlcfg.Cfg
+module BB = Cfg.Basic_block
+module CL = Ocamlcfg.Cfg_with_layout
 
-type t = Cfg.block List.t
+type t = BB.t List.t
 
-let create block = [ block ]
+let create block = [block]
 
-let append_successor (t : t) (successor : Cfg.block) =
+let append_successor (t : t) (successor : BB.t) =
   let predecessor = List.hd_exn t in
-  ( match predecessor.terminator.desc with
+  ( match (BB.terminator predecessor).desc with
   | Branch branch ->
       assert (
         List.exists branch ~f:(fun (_condition, label) ->
-            label = successor.start) )
+            label = BB.start successor) )
   | Return | Raise _ | Tailcall _ ->
       failwith "Trying to merge two incompatible blocks"
   | Switch labels ->
-      assert (Array.exists labels ~f:(fun label -> label = successor.start))
-  );
+      assert (
+        Array.exists labels ~f:(fun label -> label = BB.start successor) ) );
 
   successor :: t
 ;;
@@ -27,59 +29,6 @@ type block_print_mode =
   | As_assembly
   | As_cfg
   | Both
-
-let print_assembly (t : t) =
-  let fun_body =
-    match
-      List.fold t ~init:`End ~f:(fun acc block ->
-          let terminator =
-            match acc with
-            | `End ->
-                Cfg_builder.linearize_terminator block.terminator
-                  ~next:Cfg_builder.labelled_insn_end
-            | `Middle (previous_block_label, fun_body) ->
-                Cfg_builder.linearize_terminator block.terminator
-                  ~next:{ label = previous_block_label; insn = fun_body }
-          in
-          let fun_body =
-            List.fold_right block.body ~init:terminator
-              ~f:Cfg_builder.basic_to_linear
-          in
-          let first_insn =
-            {
-              Linear.desc = Linear.Llabel block.start;
-              next = fun_body;
-              arg = [||];
-              res = [||];
-              dbg = Debuginfo.none;
-              live = Reg.Set.empty;
-            }
-          in
-          `Middle (block.start, first_insn))
-    with
-    | `End -> failwith "Encountered empty loop_free_block!"
-    | `Middle (first_block_label, fun_body) ->
-        assert (first_block_label = (List.last_exn t).start);
-        fun_body
-  in
-  let fundecl =
-    {
-      Linear.fun_name = "_fun_start_";
-      fun_body;
-      fun_fast = false;
-      fun_dbg = Debuginfo.none;
-      fun_spacetime_shape = None;
-      fun_num_stack_slots = Caml.Array.make Proc.num_register_classes 0;
-      fun_frame_required = false;
-      fun_prologue_required = false;
-      fun_contains_calls = false;
-    }
-  in
-  X86_proc.reset_asm_code ();
-  Emit.fundecl fundecl;
-  X86_proc.generate_code
-    (Some (X86_gas.generate_asm !Emitaux.output_channel))
-;;
 
 let print_cfg (t : t) =
   let init_indent = !Sexp.default_indent in
@@ -102,8 +51,8 @@ let print_cfg (t : t) =
           |> Seq.fold_left (fun x a -> a :: x) []
           |> Array.of_list )
       in
-      printf ".L%d:\n" block.start;
-      List.iter block.body ~f:(fun instruction ->
+      printf ".L%d:\n" (BB.start block);
+      List.iter (BB.body block) ~f:(fun instruction ->
           sprintf
             !"%{sexp:Types.From_cfg.basic}: Arg%{sexp:string array} \
               Res%{sexp:string array} Live%{sexp: string array}\n"
@@ -116,17 +65,19 @@ let print_cfg (t : t) =
       sprintf
         !"#-%{sexp:Types.From_cfg.terminator}-# Arg%{sexp:string array} \
           Res%{sexp:string array} Live%{sexp: string array} \n"
-        block.terminator.desc
-        (print_registers block.terminator.arg)
-        (print_registers block.terminator.res)
-        (print_live block.terminator.live)
+        (BB.terminator block).desc
+        (print_registers (BB.terminator block).arg)
+        (print_registers (BB.terminator block).res)
+        (print_live (BB.terminator block).live)
       |> indent_string |> print_endline);
 
   Sexp.default_indent := init_indent
 ;;
 
 let print (t : t) (block_print_mode : block_print_mode) =
-  let ids_of_blocks_contained = List.map t ~f:(fun block -> block.start) in
+  let ids_of_blocks_contained =
+    List.map t ~f:(fun block -> BB.start block)
+  in
   print_endline
     (Utils.color Green
        (sprintf
@@ -134,30 +85,31 @@ let print (t : t) (block_print_mode : block_print_mode) =
           (List.rev ids_of_blocks_contained)));
 
   ( match block_print_mode with
-  | As_assembly -> print_assembly t
+  | As_assembly -> (
+      match t with
+      | [] -> failwith "Encountered empty loop_free_block!"
+      | _ -> Ocamlcfg.Util.print_assembly (List.rev t) )
   | As_cfg -> print_cfg t
   | Both ->
-      print_assembly t;
+      Ocamlcfg.Util.print_assembly (List.rev t);
       print_endline (Utils.color Green (String.make 10 '='));
       print_cfg t );
   print_endline (Utils.color Green "}")
 ;;
 
 let read_file ~(file : Filename.t) ~context_length =
-  let rec generate_context_for_block (block : Cfg.block) cfg_builder context
-      =
+  let rec generate_context_for_block (block : BB.t) cfg context =
     match context with
     | 0 -> [| create block |]
     | _ ->
         Array.concat_map
-          (Cfg.LabelSet.elements block.predecessors |> Array.of_list)
+          (Cfg.predecessors block |> Array.of_list)
           ~f:(fun label ->
             let previous_block =
-              Cfg_builder.get_block cfg_builder label |> Option.value_exn
+              Cfg.get_block cfg label |> Option.value_exn
             in
             Array.map
-              (generate_context_for_block previous_block cfg_builder
-                 (context - 1))
+              (generate_context_for_block previous_block cfg (context - 1))
               ~f:(fun predecessor -> append_successor predecessor block))
   in
   let open Linear_format in
@@ -165,17 +117,13 @@ let read_file ~(file : Filename.t) ~context_length =
   List.filter_map ui.items ~f:(fun item ->
       match item with
       | Func f ->
-          let cfg_builder =
-            Cfg_builder.from_linear f ~preserve_orig_labels:true
-          in
-          let layout = Cfg_builder.get_layout cfg_builder in
+          let cl = CL.of_linear f ~preserve_orig_labels:true in
+          let cfg = CL.cfg cl in
+          let layout = CL.layout cl in
           let blocks =
             Array.concat_map (Array.of_list layout) ~f:(fun label ->
-                let block =
-                  Cfg_builder.get_block cfg_builder label
-                  |> Option.value_exn
-                in
-                generate_context_for_block block cfg_builder context_length)
+                let block = Cfg.get_block cfg label |> Option.value_exn in
+                generate_context_for_block block cfg context_length)
           in
           Some (f, blocks)
       | Data _ -> None)

--- a/lib/loop_free_block.mli
+++ b/lib/loop_free_block.mli
@@ -1,12 +1,12 @@
-open Ocamlcfg
+module BB = Ocamlcfg.Cfg.Basic_block
 
 type t
 
-val create : Cfg.block -> t
+val create : BB.t -> t
 
-val append_successor : t -> Cfg.block -> t
+val append_successor : t -> BB.t -> t
 
-val to_list : t -> Cfg.block List.t
+val to_list : t -> BB.t List.t
 
 type block_print_mode =
   | As_assembly

--- a/ocaml-instr-freq.install
+++ b/ocaml-instr-freq.install
@@ -1,0 +1,8 @@
+lib: [
+  "_build/install/default/lib/ocaml-instr-freq/META"
+  "_build/install/default/lib/ocaml-instr-freq/dune-package"
+  "_build/install/default/lib/ocaml-instr-freq/opam"
+]
+doc: [
+  "_build/install/default/doc/ocaml-instr-freq/README.md"
+]

--- a/ocaml-instr-freq.opam
+++ b/ocaml-instr-freq.opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+name: "ocaml-instr-freq"
+maintainer: "Eric Stavarache <ericptst@gmail.com>"
+authors: "Eric Stavarache <ericptst@gmail.com>"
+homepage: "https://github.com/ericpts/ocaml-instr-freq"
+bug-reports: "https://github.com/ericpts/ocaml-instr-freq/issues"
+license: "GNU Lesser General Public License version 2.1"
+dev-repo: "git+https://ericpts/ocaml-instr-freq.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune" {build & >= "1.8"}
+  "ocamlcfg"
+  "core"
+  "async"
+  "ppx_jane" {>= "v0.13.0"}
+]
+synopsis: "Count frequency of basic blocks in OCaml native code"
+description: "This is useful for knowing which optimizations
+would have the most impact, if they were to be implemented in the compiler.
+Currently, this only works for x86-64 targets. "

--- a/patterns/pattern_double_mov.ml
+++ b/patterns/pattern_double_mov.ml
@@ -5,7 +5,11 @@ let f ~(block : Index.Matcher.Whole_block_predicate.block) =
   Lib.any_suffix ~block ~f:(function
     | { desc = Basic (Op Move); arg = _; res = [| move1_destination |] }
       :: { desc = Basic (Op Move); arg = [| move2_source |]; res = _ } :: _
-      when move1_destination = move2_source ->
-        true
+      ->
+        if
+          Equivalence.Register_equivalence.equal move1_destination
+            move2_source
+        then true
+        else false
     | _ -> false)
 ;;

--- a/patterns/pattern_load_add.ml
+++ b/patterns/pattern_load_add.ml
@@ -12,9 +12,12 @@ let f ~(block : Index.Matcher.Whole_block_predicate.block) =
             Index.Matcher.Basic (Op (Intop _));
           arg = [| intop_input1; intop_input2 |];
           res = [| intop_output |]
-        }
-      ]
-      when load_destination = intop_input2 && intop_input1 = intop_output ->
-        true
+        } ] ->
+        if
+          Equivalence.Register_equivalence.equal load_destination
+            intop_input2
+          && Equivalence.Register_equivalence.equal intop_input1 intop_output
+        then true
+        else false
     | _ -> false)
 ;;

--- a/test/dune
+++ b/test/dune
@@ -2,6 +2,7 @@
  (name test)
  (libraries
   core
+  compiler-libs.optcomp
   ocamlcfg
   instr_freq
   async

--- a/test/test.expected
+++ b/test/test.expected
@@ -1,40 +1,39 @@
 test_matching_functionality
 There are a total of 2 blocks matching the query criteria.
-Equivalence [38;5;6m<6>[0m with 1 members;
+Equivalence [38;5;6m<8>[0m with 1 members;
 	file: [38;5;6msimple.ml[0m
 	function: [38;5;6mcamlSimple__impl_36[0m
-[38;5;2mBlocks (105): {[0m
+[38;5;2mBlocks (107): {[0m
 	.file ""
-	.section .text._fun_start_,"ax",@progbits
+	.text
 	.align	16
 	.globl	_fun_start_
 _fun_start_:
 	.cfi_startproc
-.L105:
 	movq	%rax, %rdi
 	sarq	$1, %rdi
 	decq	%rbx
 	imulq	%rdi, %rbx
 	incq	%rbx
 	addq	$-2, %rax
-	jmp	camlSimple__impl_36@PLT
+	jmp	.L0
 	.cfi_endproc
 	.type _fun_start_,@function
 	.size _fun_start_,. - _fun_start_
 [38;5;2m}[0m
 test_index_bigger_file
-Equivalence [38;5;6m<1>[0m with 3 members;
+Equivalence [38;5;6m<2>[0m with 3 members;
 	file: [38;5;6mrepetitive.ml[0m
 	function: [38;5;6mcamlRepetitive__f0_11[0m
-[38;5;2mBlocks (109): {[0m
-.L109:
+[38;5;2mBlocks (113): {[0m
+.L113:
 	(Op Spill): Arg(reg#0) Res(stack#local#0) Live(reg#0)
 	(Op (Intop_imm Iadd -4)): Arg(reg#0) Res(reg#0) Live(stack#local#0)
-	(Call (F (Immediate (func camlRepetitive__f0_11) (label_after 100)))): Arg(reg#0) Res(reg#0) Live(stack#local#0)
+	(Call (F (Direct (func_symbol camlRepetitive__f0_11) (label_after 100)))): Arg(reg#0) Res(reg#0) Live(stack#local#0)
 	(Op Spill): Arg(reg#0) Res(stack#local#1) Live(stack#local#0)
 	(Op Reload): Arg(stack#local#0) Res(reg#0) Live(stack#local#1)
 	(Op (Intop_imm Iadd -2)): Arg(reg#0) Res(reg#0) Live(stack#local#1)
-	(Call (F (Immediate (func camlRepetitive__f0_11) (label_after 101)))): Arg(reg#0) Res(reg#0) Live(stack#local#1)
+	(Call (F (Direct (func_symbol camlRepetitive__f0_11) (label_after 101)))): Arg(reg#0) Res(reg#0) Live(stack#local#1)
 	(Op Reload): Arg(stack#local#1) Res(reg#1) Live(reg#0)
 	(Op (Intop Iadd)): Arg(reg#0 reg#1) Res(reg#0) Live()
 	(Op (Intop_imm Iadd -1)): Arg(reg#0) Res(reg#0) Live()
@@ -42,21 +41,19 @@ Equivalence [38;5;6m<1>[0m with 3 members;
 	#-Return-# Arg(reg#0) Res() Live() 
 [38;5;2m}[0m
 test_index_context
-Equivalence [38;5;6m<0>[0m with 3 members;
+Equivalence [38;5;6m<1>[0m with 3 members;
 	file: [38;5;6mrepetitive.ml[0m
 	function: [38;5;6mcamlRepetitive__f0_11[0m
-[38;5;2mBlocks (0 109): {[0m
+[38;5;2mBlocks (103 113): {[0m
 	.file ""
-	.section .text._fun_start_,"ax",@progbits
+	.text
 	.align	16
 	.globl	_fun_start_
 _fun_start_:
 	.cfi_startproc
-.L0:
-.L112:
 	cmpq	$3, %rax
 	jbe	.L102
-.L109:
+.L113:
 	movq	%rax, (%rsp)
 	addq	$-4, %rax
 	call	camlRepetitive__f0_11@PLT
@@ -74,19 +71,18 @@ _fun_start_:
 	.type _fun_start_,@function
 	.size _fun_start_,. - _fun_start_
 [38;5;2m==========[0m
-.L0:
-	Prologue: Arg() Res() Live()
+.L103:
 	#-(Branch
 	    (((Test (Iinttest_imm (Iunsigned Cle) 3)) 102)
-	        ((Test (Iinttest_imm (Iunsigned Cgt) 3)) 109)))-# Arg(reg#0) Res() Live() 
-.L109:
+	        ((Test (Iinttest_imm (Iunsigned Cgt) 3)) 113)))-# Arg(reg#0) Res() Live() 
+.L113:
 	(Op Spill): Arg(reg#0) Res(stack#local#0) Live(reg#0)
 	(Op (Intop_imm Iadd -4)): Arg(reg#0) Res(reg#0) Live(stack#local#0)
-	(Call (F (Immediate (func camlRepetitive__f0_11) (label_after 100)))): Arg(reg#0) Res(reg#0) Live(stack#local#0)
+	(Call (F (Direct (func_symbol camlRepetitive__f0_11) (label_after 100)))): Arg(reg#0) Res(reg#0) Live(stack#local#0)
 	(Op Spill): Arg(reg#0) Res(stack#local#1) Live(stack#local#0)
 	(Op Reload): Arg(stack#local#0) Res(reg#0) Live(stack#local#1)
 	(Op (Intop_imm Iadd -2)): Arg(reg#0) Res(reg#0) Live(stack#local#1)
-	(Call (F (Immediate (func camlRepetitive__f0_11) (label_after 101)))): Arg(reg#0) Res(reg#0) Live(stack#local#1)
+	(Call (F (Direct (func_symbol camlRepetitive__f0_11) (label_after 101)))): Arg(reg#0) Res(reg#0) Live(stack#local#1)
 	(Op Reload): Arg(stack#local#1) Res(reg#1) Live(reg#0)
 	(Op (Intop Iadd)): Arg(reg#0 reg#1) Res(reg#0) Live()
 	(Op (Intop_imm Iadd -1)): Arg(reg#0) Res(reg#0) Live()
@@ -94,18 +90,22 @@ _fun_start_:
 	#-Return-# Arg(reg#0) Res() Live() 
 [38;5;2m}[0m
 test_index_context_with_matcher
-Equivalence [38;5;6m<3>[0m with 2 members;
+Equivalence [38;5;6m<4>[0m with 2 members;
 	file: [38;5;6mlong_function.ml[0m
 	function: [38;5;6mcamlLong_function__matrix_multiply_8[0m
-[38;5;2mBlocks (118 107 119): {[0m
+[38;5;2mBlocks (108 107 122): {[0m
 	.file ""
-	.section .text._fun_start_,"ax",@progbits
+	.text
 	.align	16
 	.globl	_fun_start_
 _fun_start_:
 	.cfi_startproc
-.L118:
-	movq	$1, %rbx
+	cmpq	$1023, %rdi
+	jbe	.L125
+	movq	(%rbx), %rbx
+	movq	-8(%rbx), %rbx
+	shrq	$9, %rbx
+	orq	$1, %rbx
 	movq	%rbx, 8(%rsp)
 .L107:
 	movq	$1, %rdi
@@ -116,15 +116,24 @@ _fun_start_:
 	addq	$-2, %rbx
 	cmpq	%rbx, %rdx
 	jg	.L101
-.L119:
+.L122:
 	movq	%rbx, (%rsp)
 	jmp	.L102
+.L125:
+	call	caml_ml_array_bound_error@PLT
 	.cfi_endproc
 	.type _fun_start_,@function
 	.size _fun_start_,. - _fun_start_
 [38;5;2m==========[0m
-.L118:
-	(Op (Const_int 1)): Arg() Res(reg#1) Live(stack#local#0 stack#local#2 stack#local#3 stack#local#4 reg#0)
+.L108:
+	(Call
+	    (P
+	        (Checkbound (immediate (1023)) (label_after_error ())
+	            (spacetime_index 0)))): Arg(reg#2) Res() Live(stack#local#0 stack#local#2 stack#local#3 stack#local#4 reg#0 reg#1)
+	(Op (Load Word_val (Iindexed 0))): Arg(reg#1) Res(reg#1) Live(stack#local#0 stack#local#2 stack#local#3 stack#local#4 reg#0)
+	(Op (Load Word_int (Iindexed -8))): Arg(reg#1) Res(reg#1) Live(stack#local#0 stack#local#2 stack#local#3 stack#local#4 reg#0)
+	(Op (Intop_imm Ilsr 9)): Arg(reg#1) Res(reg#1) Live(stack#local#0 stack#local#2 stack#local#3 stack#local#4 reg#0)
+	(Op (Intop_imm Ior 1)): Arg(reg#1) Res(reg#1) Live(stack#local#0 stack#local#2 stack#local#3 stack#local#4 reg#0)
 	(Op Spill): Arg(reg#1) Res(stack#local#1) Live(stack#local#0 stack#local#2 stack#local#3 stack#local#4 reg#1 reg#0)
 	#-(Branch ((Always 107)))-# Arg() Res() Live() 
 .L107:
@@ -132,32 +141,30 @@ _fun_start_:
 	    reg#0)
 	(Call
 	    (F
-	        (Immediate (func camlStdlib__array__make_matrix_142)
+	        (Direct (func_symbol camlStdlib__array__make_matrix_142)
 	            (label_after 100)))): Arg(reg#0 reg#1 reg#2) Res(reg#0) Live(stack#local#0 stack#local#1 stack#local#2 stack#local#3 stack#local#4)
 	(Op (Const_int 1)): Arg() Res(reg#4) Live(stack#local#0 stack#local#1 stack#local#2 stack#local#3 stack#local#4 reg#0)
 	(Op Reload): Arg(stack#local#0) Res(reg#1) Live(stack#local#1 stack#local#2 stack#local#3 stack#local#4 reg#4 reg#0)
 	(Op (Intop_imm Iadd -2)): Arg(reg#1) Res(reg#1) Live(stack#local#1 stack#local#2 stack#local#3 stack#local#4 reg#4 reg#0)
 	#-(Branch
 	    (((Test (Iinttest (Isigned Cgt))) 101)
-	        ((Test (Iinttest (Isigned Cle))) 119)))-# Arg(reg#4 reg#1) Res() Live() 
-.L119:
+	        ((Test (Iinttest (Isigned Cle))) 122)))-# Arg(reg#4 reg#1) Res() Live() 
+.L122:
 	(Op Spill): Arg(reg#1) Res(stack#local#0) Live(stack#local#1 stack#local#2 stack#local#3 stack#local#4 reg#4 reg#0)
 	#-(Branch ((Always 102)))-# Arg() Res() Live() 
 [38;5;2m}[0m
 test_index_whole_block_matcher
 There are a total of 5 blocks matching the query criteria.
-Equivalence [38;5;6m<0>[0m with 2 members;
+Equivalence [38;5;6m<1>[0m with 2 members;
 	file: [38;5;6mlong_function.ml[0m
 	function: [38;5;6mcamlLong_function__matrix_multiply_8[0m
-[38;5;2mBlocks (0): {[0m
+[38;5;2mBlocks (109): {[0m
 	.file ""
-	.section .text._fun_start_,"ax",@progbits
+	.text
 	.align	16
 	.globl	_fun_start_
 _fun_start_:
 	.cfi_startproc
-.L0:
-.L122:
 	movq	%rax, 32(%rsp)
 	movq	%rbx, 24(%rsp)
 	movq	-8(%rax), %rax
@@ -171,13 +178,12 @@ _fun_start_:
 	movq	%rsi, 16(%rsp)
 	cmpq	$1, %rsi
 	jne	.L108
-	jmp	.L118
+	jmp	.L121
 	.cfi_endproc
 	.type _fun_start_,@function
 	.size _fun_start_,. - _fun_start_
 [38;5;2m==========[0m
-.L0:
-	Prologue: Arg() Res() Live(reg#0 reg#1)
+.L109:
 	(Op Spill): Arg(reg#0) Res(stack#local#4) Live(reg#0 reg#1)
 	(Op Spill): Arg(reg#1) Res(stack#local#3) Live(stack#local#4 reg#1 reg#0)
 	(Op (Load Word_int (Iindexed -8))): Arg(reg#0) Res(reg#0) Live(stack#local#3 stack#local#4 reg#1)
@@ -191,5 +197,5 @@ _fun_start_:
 	(Op Spill): Arg(reg#3) Res(stack#local#2) Live(stack#local#0 stack#local#3 stack#local#4 reg#3 reg#2 reg#0 reg#1)
 	#-(Branch
 	    (((Test (Iinttest_imm (Isigned Cne) 1)) 108)
-	        ((Test (Iinttest_imm (Isigned Ceq) 1)) 118)))-# Arg(reg#3) Res() Live() 
+	        ((Test (Iinttest_imm (Isigned Ceq) 1)) 121)))-# Arg(reg#3) Res() Live() 
 [38;5;2m}[0m

--- a/test/test.ml
+++ b/test/test.ml
@@ -11,7 +11,7 @@ end
 
 let find_fixtures_directory () =
   let rec walk cur =
-    if cur = Filename.root then
+    if String.equal cur Filename.root then
       failwith
         "Could not find fixtures directory! Make sure that you are running \
          the test from the project's root, or a subdirectory.";
@@ -38,8 +38,8 @@ let matcher_of_sexp sexp =
   matcher
 ;;
 
-let build_index_for_fixture
-    ~fixtures_directory ~context_length ~fixture_file =
+let build_index_for_fixture ~fixtures_directory ~context_length ~fixture_file
+    =
   let ml_file = fixtures_directory ^/ fixture_file in
   let open Async in
   (* Don't enter the async monad, to preserve error message call stacks, in
@@ -48,15 +48,12 @@ let build_index_for_fixture
       Process.run_expect_no_output_exn () ~prog:"ocamlopt"
         ~args:
           [ "-save-ir-after";
-            "linearize";
+            "scheduling";
             "-stop-after";
-            "linearize";
-            ml_file
-          ]);
+            "scheduling";
+            ml_file ]);
   let linear_file = Filename.chop_extension ml_file ^ ".cmir-linear" in
-  let blocks =
-    Loop_free_block.read_file ~file:linear_file ~context_length
-  in
+  let blocks = Loop_free_block.read_file ~file:linear_file ~context_length in
   let index = Index.empty () in
   List.iter blocks ~f:(fun (_fundecl, loop_free_blocks) ->
       Array.iter loop_free_blocks ~f:(fun loop_free_block ->
@@ -65,14 +62,13 @@ let build_index_for_fixture
 ;;
 
 let iter_blocks blocks ~index ~file ~statistics =
-  let { Stats.on_block; on_finish_iteration; hint_files = _ } =
-    statistics
-  in
+  let { Stats.on_block; on_finish_iteration; hint_files = _ } = statistics in
   List.iter blocks ~f:(fun (fundecl, loop_free_blocks) ->
       Array.iter loop_free_blocks ~f:(fun block ->
           let equivalence = Index.equivalence_exn index block in
           let frequency = Index.frequency_exn index equivalence in
-          on_block block ~file ~equivalence ~frequency ~fundecl |> ignore));
+          match on_block block ~file ~equivalence ~frequency ~fundecl with
+          | _ -> ()));
   on_finish_iteration ()
 ;;
 
@@ -88,9 +84,9 @@ let test_index_statistics ~fixtures_directory =
       } =
     Index.hashtbl_load_statistics index
   in
-  [%test_result: int] ~expect:8 n_symbolic_blocks;
+  [%test_result: int] ~expect:10 n_symbolic_blocks;
   [%test_result: int] ~expect:11 n_basic_instructions;
-  [%test_result: int] ~expect:4 n_terminator_instructions
+  [%test_result: int] ~expect:6 n_terminator_instructions
 ;;
 
 let test_matching_functionality ~fixtures_directory =
@@ -116,8 +112,7 @@ let test_matching_functionality ~fixtures_directory =
         Stats.print_most_popular_classes index ~n_real_blocks_to_print:1
           ~n_most_frequent_equivalences:1
           ~block_print_mode:Loop_free_block.As_assembly ~min_block_size:0
-          ~matcher
-      ]
+          ~matcher ]
   in
   iter_blocks blocks ~index ~file:fixture_file ~statistics
 ;;
@@ -134,8 +129,7 @@ let test_index_bigger_file ~fixtures_directory =
       [ Stats.print_most_popular_classes index ~n_real_blocks_to_print:1
           ~n_most_frequent_equivalences:1
           ~block_print_mode:Loop_free_block.As_cfg ~min_block_size:4
-          ~matcher:None
-      ]
+          ~matcher:None ]
   in
   iter_blocks blocks ~index ~file:fixture_file ~statistics
 ;;
@@ -152,8 +146,7 @@ let test_index_context ~fixtures_directory =
       [ Stats.print_most_popular_classes index ~n_real_blocks_to_print:1
           ~n_most_frequent_equivalences:1
           ~block_print_mode:Loop_free_block.Both ~min_block_size:6
-          ~matcher:None
-      ]
+          ~matcher:None ]
   in
   iter_blocks blocks ~index ~file:fixture_file ~statistics
 ;;


### PR DESCRIPTION
New version of ocamlcfg does not support modification of an existing CFG outside the library, which can only be constructed from Linear IR. 

The new ocamlcfg is based on 4.09 OCaml compiler, which does not yet support -save-ir and -stop-after-scheduling. These features are backported to a new ocam-variant branch based on 4.09.0.

This compiler version includes changes to prologue instruction in Linear. Adapted test accordingly (hopefully correctly).

Added opam file to make it easier to install the correct version of ppx_jane, etc. Updated README instructions accordingly.
